### PR TITLE
Fix bug when change filters (app crash)

### DIFF
--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -271,10 +271,9 @@ public class SvrfSDK: NSObject {
     public static func setBlendShapes(blendShapes: [ARFaceAnchor.BlendShapeLocation: NSNumber], for node: SCNNode) {
 
         node.enumerateHierarchy { (childNode, _) in
-
-            for (blendShape, weight) in blendShapes {
-                let targetName = blendShape.rawValue
-                DispatchQueue.main.async {
+            DispatchQueue.main.async {
+                for (blendShape, weight) in blendShapes {
+                    let targetName = blendShape.rawValue
                     childNode.morpher?.setWeight(CGFloat(weight.floatValue), forTargetNamed: targetName)
                 }
             }

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -274,7 +274,9 @@ public class SvrfSDK: NSObject {
 
             for (blendShape, weight) in blendShapes {
                 let targetName = blendShape.rawValue
-                childNode.morpher?.setWeight(CGFloat(weight.floatValue), forTargetNamed: targetName)
+                DispatchQueue.main.async {
+                    childNode.morpher?.setWeight(CGFloat(weight.floatValue), forTargetNamed: targetName)
+                }
             }
         }
     }

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -270,8 +270,8 @@ public class SvrfSDK: NSObject {
      */
     public static func setBlendShapes(blendShapes: [ARFaceAnchor.BlendShapeLocation: NSNumber], for node: SCNNode) {
 
-        node.enumerateHierarchy { (childNode, _) in
-            DispatchQueue.main.async {
+        DispatchQueue.main.async {
+            node.enumerateHierarchy { (childNode, _) in
                 for (blendShape, weight) in blendShapes {
                     let targetName = blendShape.rawValue
                     childNode.morpher?.setWeight(CGFloat(weight.floatValue), forTargetNamed: targetName)


### PR DESCRIPTION
# Pull Request

## Description

Regarding this issue:
https://github.com/SVRF/svrf-wave/issues/1960

- Call setWeight function in the main.async thread.

So, I think this situation is not a bug.. this is kind of "ill-considered flow". This crash appears when users call our SDK's function (setBlendshapes) in the incorrect thread. After this update users don't need to think about queries in their apps. But in current version SDK we can help users avoid this problem. They just need call our method in main.async thread. They have to call method kind of this way:

'''DispatchQueue.main.async {
    SvrfSDK.setBlendShapes(blendShapes: blendShapes, for: node)
}'''

more information about this issue:
https://stackoverflow.com/q/53126186

### Motivation and Context

- closes #1960
- get rid of the crash

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Maintenance