### PR TITLE
Api key via code

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you prefer not to use dependency manager, you can integrate the **SvrfSDK** i
 
 ## Authentication
 
-Configure your `plist` with your **SVRF_API_KEY**.
+Configure your `plist` with your **SVRF_API_KEY** or pass **SVRF_API_KEY** in the authenticate function. 
 
 ```plist
 <plist version="1.0">
@@ -91,6 +91,11 @@ To authenticate the SvrfSDK, add the following to your `didFinishLaunchingWithOp
 
 ```swift
 SvrfSDK.authenticate()
+```
+or
+
+```swift
+SvrfSDK.authenticate(apiKey:**SVRF_API_KEY**)
 ```
 
 ## Endpoints

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you prefer not to use dependency manager, you can integrate the **SvrfSDK** i
 
 ## Authentication
 
-Configure your `plist` with your **SVRF_API_KEY** 
+Include your Svrf API Key in the `Authenticate()` method or configure your `plist` by adding a key **SVRF_API_KEY** with your Svrf API Key. An API Key passed through the `Authenticate()` method will take precedence over the `plist`.
 
 ```plist
 <plist version="1.0">
@@ -86,8 +86,8 @@ Configure your `plist` with your **SVRF_API_KEY**
   </dict>
 </plist>
 ```
-or pass **SVRF_API_KEY** in the authenticate function.
- 
+or
+
 ```swift
 SvrfSDK.authenticate(apiKey: **SVRF_API_KEY**)
 ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ If you prefer not to use dependency manager, you can integrate the **SvrfSDK** i
 
 Include your Svrf API Key in the `Authenticate()` method or configure your `plist` by adding a key **SVRF_API_KEY** with your Svrf API Key. An API Key passed through the `Authenticate()` method will take precedence over the `plist`.
 
+```swift
+SvrfSDK.authenticate(apiKey: **SVRF_API_KEY**)
+```
+
+or
+
 ```plist
 <plist version="1.0">
   <dict>
@@ -85,11 +91,6 @@ Include your Svrf API Key in the `Authenticate()` method or configure your `plis
     <string>{your-api-key}</string>
   </dict>
 </plist>
-```
-or
-
-```swift
-SvrfSDK.authenticate(apiKey: **SVRF_API_KEY**)
 ```
 
 To authenticate the SvrfSDK, add the following to your `didFinishLaunchingWithOptions` function in *AppDelegate*:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you prefer not to use dependency manager, you can integrate the **SvrfSDK** i
 
 ## Authentication
 
-Configure your `plist` with your **SVRF_API_KEY** or pass **SVRF_API_KEY** in the authenticate function. 
+Configure your `plist` with your **SVRF_API_KEY** 
 
 ```plist
 <plist version="1.0">
@@ -86,16 +86,16 @@ Configure your `plist` with your **SVRF_API_KEY** or pass **SVRF_API_KEY** in th
   </dict>
 </plist>
 ```
+or pass **SVRF_API_KEY** in the authenticate function.
+ 
+```swift
+SvrfSDK.authenticate(apiKey: **SVRF_API_KEY**)
+```
 
 To authenticate the SvrfSDK, add the following to your `didFinishLaunchingWithOptions` function in *AppDelegate*:
 
 ```swift
 SvrfSDK.authenticate()
-```
-or
-
-```swift
-SvrfSDK.authenticate(apiKey:**SVRF_API_KEY**)
 ```
 
 ## Endpoints

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -62,11 +62,11 @@ public class SvrfSDK: NSObject {
             var key: String?
             key = apiKey
 
-            if key == nil {
-                if let path = Bundle.main.path(forResource: "Info", ofType: "plist"),
-                    let dict = NSDictionary(contentsOfFile: path) {
-                    key = dict[svrfApiKeyKey] as? String
-                }
+            if key == nil,
+                let path = Bundle.main.path(forResource: "Info", ofType: "plist"),
+                let dict = NSDictionary(contentsOfFile: path) {
+
+                key = dict[svrfApiKeyKey] as? String
             }
 
             if let key = key {

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -39,7 +39,7 @@ public class SvrfSDK: NSObject {
         - failure: Failure closure.
         - error: A *SvrfError*.
      */
-    public static func authenticate(onSuccess success: (() -> Void)? = nil,
+    public static func authenticate(apiKey: String? = nil, onSuccess success: (() -> Void)? = nil,
                                     onFailure failure: Optional<(_ error: SvrfError) -> Void> = nil) {
 
         dispatchGroup.enter()
@@ -47,9 +47,7 @@ public class SvrfSDK: NSObject {
         setupAnalytics()
 
         if !needUpdateToken() {
-
             let authToken = String(data: (SvrfKeyChain.load(key: svrfAuthTokenKey))!, encoding: .utf8)!
-
             SVRFClientAPI.customHeaders = [svrfXAppTokenKey: authToken]
 
             if let success = success {
@@ -59,54 +57,63 @@ public class SvrfSDK: NSObject {
             dispatchGroup.leave()
 
             return
-        } else if let path = Bundle.main.path(forResource: "Info", ofType: "plist"),
-            let dict = NSDictionary(contentsOfFile: path),
-            let apiKey = dict[svrfApiKeyKey] as? String {
-
-            let body = Body(apiKey: apiKey)
-            AuthenticateAPI.authenticate(body: body) { (authResponse, error) in
-
-                if error != nil {
-                    if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.response.rawValue,
-                                          description: error?.localizedDescription))
-                    }
-
-                    dispatchGroup.leave()
-
-                    return
-                }
-
-                if let authToken = authResponse?.token, let expireIn = authResponse?.expiresIn {
-
-                    _ = SvrfKeyChain.save(key: svrfAuthTokenKey, data: Data(authToken.utf8))
-                    UserDefaults.standard.set(getTokenExpireDate(expireIn: expireIn),
-                                              forKey: svrfAuthTokenExpireDateKey)
-                    SVRFClientAPI.customHeaders = [svrfXAppTokenKey: authToken]
-
-                    if let success = success {
-                        success()
-                    }
-
-                    dispatchGroup.leave()
-
-                    return
-                } else {
-                    if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.Auth.responseNoToken.rawValue, description: nil))
-                    }
-
-                    dispatchGroup.leave()
-
-                    return
-                }
-            }
         } else {
-            if let failure = failure {
-                failure(SvrfError(title: SvrfErrorTitle.Auth.apiKey.rawValue, description: nil))
+
+            var key: String?
+            key = apiKey
+
+            if key == nil {
+                if let path = Bundle.main.path(forResource: "Info", ofType: "plist"),
+                    let dict = NSDictionary(contentsOfFile: path) {
+                    key = dict[svrfApiKeyKey] as? String
+                }
             }
 
-            dispatchGroup.leave()
+            if let key = key {
+                let body = Body(apiKey: key)
+                AuthenticateAPI.authenticate(body: body) { (authResponse, error) in
+
+                    if error != nil {
+                        if let failure = failure {
+                            failure(SvrfError(title: SvrfErrorTitle.response.rawValue,
+                                              description: error?.localizedDescription))
+                        }
+
+                        dispatchGroup.leave()
+
+                        return
+                    }
+
+                    if let authToken = authResponse?.token, let expireIn = authResponse?.expiresIn {
+                        _ = SvrfKeyChain.save(key: svrfAuthTokenKey, data: Data(authToken.utf8))
+                        UserDefaults.standard.set(getTokenExpireDate(expireIn: expireIn),
+                                                  forKey: svrfAuthTokenExpireDateKey)
+                        SVRFClientAPI.customHeaders = [svrfXAppTokenKey: authToken]
+
+                        if let success = success {
+                            success()
+                        }
+
+                        dispatchGroup.leave()
+
+                        return
+                    } else {
+                        if let failure = failure {
+                            failure(SvrfError(title: SvrfErrorTitle.Auth.responseNoToken.rawValue, description: nil))
+                        }
+
+                        dispatchGroup.leave()
+
+                        return
+                    }
+                }
+            } else {
+                if let failure = failure {
+                    failure(SvrfError(title: SvrfErrorTitle.Auth.apiKey.rawValue, description: nil))
+                }
+
+                dispatchGroup.leave()
+            }
         }
     }
 

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -35,6 +35,7 @@ public class SvrfSDK: NSObject {
      Authenticate your API Key with the Svrf API.
      
      - Parameters:
+        - apiKey: Svrf API key
         - success: Success closure.
         - failure: Failure closure.
         - error: A *SvrfError*.
@@ -59,8 +60,7 @@ public class SvrfSDK: NSObject {
             return
         } else {
 
-            var key: String?
-            key = apiKey
+            var key = apiKey
 
             if key == nil,
                 let path = Bundle.main.path(forResource: "Info", ofType: "plist"),


### PR DESCRIPTION
# Pull Request

## Description

- Now you can set your SVRF_API_KEY in the plist or in the AUTH function. If you set SVRF_API_KEY in both places - function's key will have higher priority.

### Motivation and Context

- closes #31

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Maintenance