### PR TITLE
2116 error protocol

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@
 target 'SvrfSDK' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
-  pod 'SVRFClient', '~> 1.3.2'
+  pod 'SVRFClient', '~> 1.6.0'
   pod 'SvrfGLTFSceneKit', '~> 1.0'
   pod 'Analytics', '~> 3.0'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Alamofire (4.8.1)
+  - Alamofire (4.8.2)
   - Analytics (3.6.10)
-  - SVRFClient (1.3.2):
+  - SVRFClient (1.6.0):
     - Alamofire (~> 4.8)
   - SvrfGLTFSceneKit (1.0.1)
 
 DEPENDENCIES:
   - Analytics (~> 3.0)
-  - SVRFClient (~> 1.3.2)
+  - SVRFClient (~> 1.6.0)
   - SvrfGLTFSceneKit (~> 1.0)
 
 SPEC REPOS:
@@ -18,11 +18,11 @@ SPEC REPOS:
     - SvrfGLTFSceneKit
 
 SPEC CHECKSUMS:
-  Alamofire: 16ce2c353fb72865124ddae8a57c5942388f4f11
+  Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
   Analytics: 63744ad4afa65c3bcdcdb7a94b62515bde5b3900
-  SVRFClient: e13dcd2ecddb6af9dccb7b5c433b7aefba9d8764
+  SVRFClient: eb51b21b11c262e71941b59f4197a86abd4e2724
   SvrfGLTFSceneKit: 87a93a9e34adc8ae32beb08e0b7fc7dfbbac9623
 
-PODFILE CHECKSUM: 655de524c153f1a6d85e86f27076a5b456d9e098
+PODFILE CHECKSUM: 485c29189010ff7dcb171ff8acac7d11f6e1867e
 
 COCOAPODS: 1.5.3

--- a/README.md
+++ b/README.md
@@ -271,12 +271,9 @@ class FaceFilter: SCNNode, VirtualFaceContent {
 
     var blendShapes: [ARFaceAnchor.BlendShapeLocation: NSNumber] = [:] {
         didSet {
-            // Enumerate through all child nodes to find all morpher targets
-            self.enumerateHierarchy({ (node, _) in
-                if (node.morpher?.targets != nil) {
-                    SvrfSDK.setBlendShapes(blendShapes: blendShapes, for: node)
-                }
-            })
+            if let faceFilter = faceFilter {
+                SvrfSDK.setBlendShapes(blendShapes: blendShapes, for: faceFilter)
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ If you prefer not to use dependency manager, you can integrate the **SvrfSDK** i
 
 ## Authentication
 
-Configure your `plist` with your **SVRF_API_KEY**.
+Include your Svrf API Key in the `Authenticate()` method or configure your `plist` by adding a key **SVRF_API_KEY** with your Svrf API Key. An API Key passed through the `Authenticate()` method will take precedence over the `plist`.
+
+```swift
+SvrfSDK.authenticate(apiKey: **SVRF_API_KEY**)
+```
+
+or
 
 ```plist
 <plist version="1.0">

--- a/SvrfSDK.podspec
+++ b/SvrfSDK.podspec
@@ -1,14 +1,14 @@
 Pod::Spec.new do |s|
   s.name = "SvrfSDK"
-  s.version = "1.0.4"
+  s.version = "1.1.0"
   s.summary = "The SvrfSDK is a framework for easy integration of the SVRF API"
   s.homepage = "http://www.svrf.com"
   s.license = "MIT"
   s.author = "SVRF"
   s.platform = :ios, "11.0"
-  s.source = { :git => "https://github.com/SVRF/svrf-ios-sdk.git", :tag => "1.0.4" }
+  s.source = { :git => "https://github.com/SVRF/svrf-ios-sdk.git", :tag => "1.1.0" }
   s.source_files = "SvrfSDK/Source/*"
-  s.dependency 'SVRFClient', '~> 1.3.2'
+  s.dependency 'SVRFClient', '~> 1.6.0'
   s.dependency 'SvrfGLTFSceneKit', '~> 1.0'
   s.dependency 'Analytics', '~> 3.0'
   s.swift_version = "4.0"

--- a/SvrfSDK.podspec
+++ b/SvrfSDK.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name = "SvrfSDK"
-  s.version = "1.1.0"
+  s.version = "1.2.0"
   s.summary = "The SvrfSDK is a framework for easy integration of the SVRF API"
   s.homepage = "http://www.svrf.com"
   s.license = "MIT"
   s.author = "SVRF"
   s.platform = :ios, "11.0"
-  s.source = { :git => "https://github.com/SVRF/svrf-ios-sdk.git", :tag => "1.1.0" }
+  s.source = { :git => "https://github.com/SVRF/svrf-ios-sdk.git", :tag => "1.2.0" }
   s.source_files = "SvrfSDK/Source/*"
   s.dependency 'SVRFClient', '~> 1.6.0'
   s.dependency 'SvrfGLTFSceneKit', '~> 1.0'

--- a/SvrfSDK/Info.plist
+++ b/SvrfSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.4</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/SvrfSDK/Source/SvrfError.swift
+++ b/SvrfSDK/Source/SvrfError.swift
@@ -8,12 +8,11 @@
 
 import Foundation
 
-public struct SvrfError {
-    public let title: String
-    public let description: String?
+public struct SvrfError: Error {
+    public var svrfDescription: String?
 }
 
-public enum SvrfErrorTitle: String {
+public enum SvrfErrorDescription: String {
 
     enum Auth: String {
         case responseNoToken = "There is no token in the server response."

--- a/SvrfSDK/Source/SvrfOptions.swift
+++ b/SvrfSDK/Source/SvrfOptions.swift
@@ -23,18 +23,30 @@ public struct SearchOptions {
                 stereoscopicType: MediaAPI.StereoscopicType_search? = nil,
                 category: MediaAPI.Category_search? = nil,
                 size: Int? = nil,
+                minimumWidth: Int? = nil,
+                isFaceFilter: Bool? = nil,
+                hasBlendShapes: Bool? = nil,
+                requiresBlendShapes: Bool? = nil,
                 pageNum: Int? = nil) {
         self.type = type
         self.stereoscopicType = stereoscopicType
         self.category = category
         self.size = size
+        self.minimumWidth = minimumWidth
+        self.isFaceFilter = isFaceFilter
+        self.hasBlendShapes = hasBlendShapes
+        self.requiresBlendShapes = requiresBlendShapes
         self.pageNum = pageNum
     }
-    
+
     let type: [MediaType]?
     let stereoscopicType: MediaAPI.StereoscopicType_search?
     let category: MediaAPI.Category_search?
     let size: Int?
+    let minimumWidth: Int?
+    let isFaceFilter: Bool?
+    let hasBlendShapes: Bool?
+    let requiresBlendShapes: Bool?
     let pageNum: Int?
 }
 
@@ -52,16 +64,28 @@ public struct TrendingOptions {
                 stereoscopicType: MediaAPI.StereoscopicType_getTrending? = nil,
                 category: MediaAPI.Category_getTrending? = nil,
                 size: Int? = nil,
+                minimumWidth: Int? = nil,
+                isFaceFilter: Bool? = nil,
+                hasBlendShapes: Bool? = nil,
+                requiresBlendShapes: Bool? = nil,
                 nextPageCursor: String? = nil) {
         self.type = type
         self.stereoscopicType = stereoscopicType
         self.category = category
         self.size = size
+        self.minimumWidth = minimumWidth
+        self.isFaceFilter = isFaceFilter
+        self.hasBlendShapes = hasBlendShapes
+        self.requiresBlendShapes = requiresBlendShapes
         self.nextPageCursor = nextPageCursor
     }
     let type: [MediaType]?
     let stereoscopicType: MediaAPI.StereoscopicType_getTrending?
     let category: MediaAPI.Category_getTrending?
     let size: Int?
+    let minimumWidth: Int?
+    let isFaceFilter: Bool?
+    let hasBlendShapes: Bool?
+    let requiresBlendShapes: Bool?
     let nextPageCursor: String?
 }

--- a/SvrfSDK/Source/SvrfOptions.swift
+++ b/SvrfSDK/Source/SvrfOptions.swift
@@ -9,16 +9,6 @@
 import Foundation
 import SVRFClient
 
-public enum Category: String {
-    case faceFilters = "Face Filters"
-}
-
-public enum StereoscopicType: String {
-    case none = "none"
-    case topBottom = "top-bottom"
-    case leftRight = "left-right"
-}
-
 /**
  Search endpoint parameters.
  - parameters:
@@ -30,8 +20,8 @@ public enum StereoscopicType: String {
  */
 public struct SearchOptions {
     public init(type: [MediaType]? = nil,
-                stereoscopicType: StereoscopicType? = nil,
-                category: Category? = nil,
+                stereoscopicType: MediaAPI.StereoscopicType_search? = nil,
+                category: MediaAPI.Category_search? = nil,
                 size: Int? = nil,
                 pageNum: Int? = nil) {
         self.type = type
@@ -40,10 +30,10 @@ public struct SearchOptions {
         self.size = size
         self.pageNum = pageNum
     }
-
+    
     let type: [MediaType]?
-    let stereoscopicType: StereoscopicType?
-    let category: Category?
+    let stereoscopicType: MediaAPI.StereoscopicType_search?
+    let category: MediaAPI.Category_search?
     let size: Int?
     let pageNum: Int?
 }
@@ -59,8 +49,8 @@ public struct SearchOptions {
  */
 public struct TrendingOptions {
     public init(type: [MediaType]? = nil,
-                stereoscopicType: StereoscopicType? = nil,
-                category: Category? = nil,
+                stereoscopicType: MediaAPI.StereoscopicType_getTrending? = nil,
+                category: MediaAPI.Category_getTrending? = nil,
                 size: Int? = nil,
                 nextPageCursor: String? = nil) {
         self.type = type
@@ -70,8 +60,8 @@ public struct TrendingOptions {
         self.nextPageCursor = nextPageCursor
     }
     let type: [MediaType]?
-    let stereoscopicType: StereoscopicType?
-    let category: Category?
+    let stereoscopicType: MediaAPI.StereoscopicType_getTrending?
+    let category: MediaAPI.Category_getTrending?
     let size: Int?
     let nextPageCursor: String?
 }

--- a/SvrfSDK/Source/SvrfOptions.swift
+++ b/SvrfSDK/Source/SvrfOptions.swift
@@ -16,6 +16,10 @@ import SVRFClient
  - stereoscopicType: Search only for *Media* with a particular stereoscopic type.
  - category: Search only for *Media* with a particular category.
  - size: The number of results to return per-page, from 1 to 100.
+ - minimumWidth: The minimum width for video and photo Media, in pixels.
+ - isFaceFilter: Search only for face filters.
+ - hasBlendShapes: Search only for Media that has blend shapes.
+ - requiresBlendShapes: Search only for Media that requires blend shapes.
  - pageNum: Pagination control to fetch the next page of results, if applicable.
  */
 public struct SearchOptions {
@@ -57,6 +61,10 @@ public struct SearchOptions {
  - stereoscopicType: Search only for *Media* with a particular stereoscopic type.
  - category: Search only for *Media* with a particular category.
  - size: The number of results to return per-page, from 1 to 100.
+ - minimumWidth: The minimum width for video and photo Media, in pixels.
+ - isFaceFilter: Search only for face filters.
+ - hasBlendShapes: Search only for Media that has blend shapes.
+ - requiresBlendShapes: Search only for Media that requires blend shapes.
  - nextPageCursor: Pass this cursor ID to get the next page of results.
  */
 public struct TrendingOptions {

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -35,9 +35,9 @@ public class SvrfSDK: NSObject {
      Authenticate your API Key with the Svrf API.
      
      - Parameters:
-        - apiKey: Svrf API key
+        - apiKey: Svrf API Key.
         - success: Success closure.
-        - failure: Failure closure.
+        - failure: Error closure.
         - error: A *SvrfError*.
      */
     public static func authenticate(apiKey: String? = nil, onSuccess success: (() -> Void)? = nil,
@@ -126,10 +126,10 @@ public class SvrfSDK: NSObject {
 
      - Parameters:
         - query: Url-encoded search query.
-        - options: Structure with parameters of search
+        - options: Search query options.
         - success: Success closure.
         - mediaArray: An array of *Media* from the Svrf API.
-        - nextPageNum: Number of the next page.
+        - nextPageNum: The page number of the next page.
         - failure: Error closure.
         - error: A *SvrfError*.
      */
@@ -175,7 +175,7 @@ public class SvrfSDK: NSObject {
      The trending experiences are updated regularly to ensure users always get fresh updates of immersive content.
      
      - Parameters:
-        - options: Structure with parameters of trending
+        - options: Trending request options.
         - success: Success closure.
         - mediaArray: An array of *Media* from the Svrf API.
         - nextPageCursor: Cursor of the next page.
@@ -227,10 +227,10 @@ public class SvrfSDK: NSObject {
     }
 
     /**
-     Fetch SVRF media by its ID.
+     Fetch Svrf media by its ID.
      
      - Parameters:
-        - identifier: ID of *Media* to fetch.
+        - identifier: The ID of *Media* to fetch.
         - success: Success closure.
         - media: *Media* from the Svrf API.
         - failure: Error closure.
@@ -268,8 +268,9 @@ public class SvrfSDK: NSObject {
      - Parameters:
         - media: The *Media* to generate the *SCNNode* from. The *type* must be `_3d`.
         - success: Success closure.
-        - node: The node that was gotten from the media
+        - node: The *SCNNode* generated from the *Media*.
         - failure: Error closure.
+        - error: A *SvrfError*.
      */
     public static func getNodeFromMedia(media: Media,
                                         onSuccess success: @escaping (_ node: SCNNode) -> Void,
@@ -287,16 +288,16 @@ public class SvrfSDK: NSObject {
     }
 
     /**
-     Blend shape mapping allows SVRF's ARKit compatible face filters to have animations that
+     Blend shape mapping allows Svrf's ARKit compatible face filters to have animations that
      are activated by your user's facial expressions.
      
      - Attention: This method enumerates through the node's hierarchy.
-     Any children nodes with morpher targets that follow the
+     Any children nodes with morph targets that follow the
      [ARKit blend shape naming conventions](https://developer.apple.com/documentation/arkit/arfaceanchor/blendshapelocation) will be affected.
-     - Note: The 3D animation terms "blend shapes", "morph targets", and "pose morphs" are often used interchangably.
+     - Note: The 3D animation terms "blend shapes", "morph targets", and "pose morphs" are often used interchangeably.
      - Parameters:
         - blendShapes: A dictionary of *ARFaceAnchor* blend shape locations and weights.
-        - node: The node with morpher targets.
+        - node: The node with morph targets.
      */
     public static func setBlendShapes(blendShapes: [ARFaceAnchor.BlendShapeLocation: NSNumber], for node: SCNNode) {
 
@@ -317,8 +318,9 @@ public class SvrfSDK: NSObject {
      - Parameters:
         - media: The *Media* to generate the face filter from. The *type* must be `_3d`.
         - success: Success closure.
-        - faceFilter: The node that contains face filter content
+        - faceFilter: The *SCNNode* that contains face filter content.
         - failure: Error closure.
+        - error: A *SvrfError*.
      */
     public static func getFaceFilter(with media: Media,
                                      onSuccess success: @escaping (_ faceFilter: SCNNode) -> Void,

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -297,20 +297,25 @@ public class SvrfSDK: NSObject {
      - Note: The 3D animation terms "blend shapes", "morph targets", and "pose morphs" are often used interchangeably.
      - Parameters:
         - blendShapes: A dictionary of *ARFaceAnchor* blend shape locations and weights.
-        - node: The node with morph targets.
+        - faceFilter: The node with morph targets.
      */
-    public static func setBlendShapes(blendShapes: [ARFaceAnchor.BlendShapeLocation: NSNumber], for node: SCNNode) {
+
+    public static func setBlendShapes(blendShapes: [ARFaceAnchor.BlendShapeLocation: NSNumber], for faceFilter: SCNNode) {
 
         DispatchQueue.main.async {
-            node.enumerateHierarchy { (childNode, _) in
-                for (blendShape, weight) in blendShapes {
-                    let targetName = blendShape.rawValue
-                    childNode.morpher?.setWeight(CGFloat(weight.floatValue), forTargetNamed: targetName)
+            faceFilter.enumerateHierarchy({ (node, _) in
+                if node.morpher?.targets != nil {
+                    node.enumerateHierarchy { (childNode, _) in
+                        for (blendShape, weight) in blendShapes {
+                            let targetName = blendShape.rawValue
+                            childNode.morpher?.setWeight(CGFloat(weight.floatValue), forTargetNamed: targetName)
+                        }
+                    }
                 }
-            }
+            })
         }
     }
-
+    
     /**
      The SVRF API allows you to access all of SVRF's ARKit compatible face filters and stream them directly to your app.
      Use the `getFaceFilter` method to stream a face filter to your app and convert it into a *SCNNode* in runtime.

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -75,8 +75,7 @@ public class SvrfSDK: NSObject {
 
                     if error != nil {
                         if let failure = failure {
-                            failure(SvrfError(title: SvrfErrorTitle.response.rawValue,
-                                              description: error?.localizedDescription))
+                            failure(SvrfError(svrfDescription: SvrfErrorDescription.response.rawValue))
                         }
 
                         dispatchGroup.leave()
@@ -99,7 +98,7 @@ public class SvrfSDK: NSObject {
                         return
                     } else {
                         if let failure = failure {
-                            failure(SvrfError(title: SvrfErrorTitle.Auth.responseNoToken.rawValue, description: nil))
+                            failure(SvrfError(svrfDescription: SvrfErrorDescription.Auth.responseNoToken.rawValue))
                         }
 
                         dispatchGroup.leave()
@@ -109,7 +108,7 @@ public class SvrfSDK: NSObject {
                 }
             } else {
                 if let failure = failure {
-                    failure(SvrfError(title: SvrfErrorTitle.Auth.apiKey.rawValue, description: nil))
+                    failure(SvrfError(svrfDescription: SvrfErrorDescription.Auth.apiKey.rawValue))
                 }
 
                 dispatchGroup.leave()
@@ -153,15 +152,15 @@ public class SvrfSDK: NSObject {
                             completion: { (searchMediaResponse, error) in
 
                 if let error = error {
-                    if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.response.rawValue,
-                                          description: error.localizedDescription))
+                    if let failure = failure, var svrfError = error as? SvrfError {
+                        svrfError.svrfDescription = SvrfErrorDescription.response.rawValue
+                        failure(svrfError)
                     }
                 } else {
                     if let mediaArray = searchMediaResponse?.media {
                         success(mediaArray, searchMediaResponse?.nextPageNum)
                     } else if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.responseNoMediaArray.rawValue, description: nil))
+                        failure(SvrfError(svrfDescription: SvrfErrorDescription.responseNoMediaArray.rawValue))
                     }
                 }
             })
@@ -206,9 +205,9 @@ public class SvrfSDK: NSObject {
                                  completion: { (trendingResponse, error) in
 
                 if let error = error {
-                    if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.response.rawValue,
-                                          description: error.localizedDescription))
+                    if let failure = failure, var svrfError = error as? SvrfError {
+                        svrfError.svrfDescription = SvrfErrorDescription.response.rawValue
+                        failure(svrfError)
                     }
                 } else {
                     if let mediaArray = trendingResponse?.media {
@@ -219,7 +218,7 @@ public class SvrfSDK: NSObject {
                         }
                         success(mediaArray, nextPageCursor)
                     } else if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.responseNoMediaArray.rawValue, description: ""))
+                        failure(SvrfError(svrfDescription: SvrfErrorDescription.responseNoMediaArray.rawValue))
                     }
                 }
             })
@@ -245,15 +244,15 @@ public class SvrfSDK: NSObject {
             MediaAPI.getById(id: identifier, completion: { (singleMediaResponse, error) in
 
                 if let error = error {
-                    if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.response.rawValue,
-                                          description: error.localizedDescription))
+                    if let failure = failure, var svrfError = error as? SvrfError {
+                        svrfError.svrfDescription = SvrfErrorDescription.response.rawValue
+                        failure(svrfError)
                     }
                 } else {
                     if let media = singleMediaResponse?.media {
                         success(media)
                     } else if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.response.rawValue, description: nil))
+                        failure(SvrfError(svrfDescription: SvrfErrorDescription.response.rawValue))
                     }
                 }
             })
@@ -280,10 +279,10 @@ public class SvrfSDK: NSObject {
             if let scene = getSceneFromMedia(media: media) {
                 success(scene.rootNode)
             } else if let failure = failure {
-                failure(SvrfError(title: SvrfErrorTitle.getScene.rawValue, description: nil))
+                failure(SvrfError(svrfDescription: SvrfErrorDescription.getScene.rawValue))
             }
         } else if let failure = failure {
-            failure(SvrfError(title: SvrfErrorTitle.incorrectMediaType.rawValue, description: nil))
+            failure(SvrfError(svrfDescription: SvrfErrorDescription.incorrectMediaType.rawValue))
         }
     }
 
@@ -315,7 +314,7 @@ public class SvrfSDK: NSObject {
             })
         }
     }
-    
+
     /**
      The SVRF API allows you to access all of SVRF's ARKit compatible face filters and stream them directly to your app.
      Use the `getFaceFilter` method to stream a face filter to your app and convert it into a *SCNNode* in runtime.
@@ -355,8 +354,7 @@ public class SvrfSDK: NSObject {
                                                 properties: ["media_id": media.id ?? "unknown"])
                 } catch {
                     if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.getScene.rawValue,
-                                          description: error.localizedDescription))
+                        failure(SvrfError(svrfDescription: SvrfErrorDescription.getScene.rawValue))
                     }
                 }
             }

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -22,13 +22,13 @@ private enum ChildNode: String {
 
 public class SvrfSDK: NSObject {
 
-    private static let svrfApiKeyKey = "SVRF_API_KEY"
-    private static let svrfXAppTokenKey = "x-app-token"
-    private static let svrfAuthTokenKey = "SVRF_AUTH_TOKEN"
-    private static let svrfAuthTokenExpireDateKey = "SVRF_AUTH_TOKEN_EXPIRE_DATE"
-    private static let svrfAnalyticsKey = "J2bIzgOhVGqDQ9ZNqVgborNthH6bpKoA"
-
     private static let dispatchGroup = DispatchGroup()
+
+    private static let svrfAnalyticsKey = "J2bIzgOhVGqDQ9ZNqVgborNthH6bpKoA"
+    private static let svrfApiKeyKey = "SVRF_API_KEY"
+    private static let svrfAuthTokenExpireDateKey = "SVRF_AUTH_TOKEN_EXPIRE_DATE"
+    private static let svrfAuthTokenKey = "SVRF_AUTH_TOKEN"
+    private static let svrfXAppTokenKey = "x-app-token"
 
     // MARK: public functions
     /**

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -145,7 +145,12 @@ public class SvrfSDK: NSObject {
                             stereoscopicType: options.stereoscopicType,
                             category: options.category,
                             size: options.size,
-                            pageNum: options.pageNum) { (searchMediaResponse, error) in
+                            minimumWidth: options.minimumWidth,
+                            pageNum: options.pageNum,
+                            isFaceFilter: options.isFaceFilter,
+                            hasBlendShapes: options.hasBlendShapes,
+                            requiresBlendShapes: options.requiresBlendShapes,
+                            completion: { (searchMediaResponse, error) in
 
                 if let error = error {
                     if let failure = failure {
@@ -159,7 +164,7 @@ public class SvrfSDK: NSObject {
                         failure(SvrfError(title: SvrfErrorTitle.responseNoMediaArray.rawValue, description: nil))
                     }
                 }
-            }
+            })
         }
     }
 
@@ -193,7 +198,11 @@ public class SvrfSDK: NSObject {
                                  stereoscopicType: options?.stereoscopicType,
                                  category: options?.category,
                                  size: options?.size,
+                                 minimumWidth: options?.minimumWidth,
                                  pageNum: pageNum,
+                                 isFaceFilter: options?.isFaceFilter,
+                                 hasBlendShapes: options?.hasBlendShapes,
+                                 requiresBlendShapes: options?.requiresBlendShapes,
                                  completion: { (trendingResponse, error) in
 
                 if let error = error {
@@ -383,7 +392,7 @@ public class SvrfSDK: NSObject {
          - Returns: Bool
          */
     private static func needUpdateToken() -> Bool {
-        
+
         if let tokenExpirationDate = UserDefaults.standard.object(forKey: svrfAuthTokenExpireDateKey) as? Date,
             let receivedData = SvrfKeyChain.load(key: svrfAuthTokenKey),
             String(data: receivedData, encoding: .utf8) != nil {

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -142,8 +142,8 @@ public class SvrfSDK: NSObject {
 
             MediaAPI.search(q: query,
                             type: options.type,
-                            stereoscopicType: options.stereoscopicType?.rawValue,
-                            category: options.category?.rawValue,
+                            stereoscopicType: options.stereoscopicType,
+                            category: options.category,
                             size: options.size,
                             pageNum: options.pageNum) { (searchMediaResponse, error) in
 
@@ -184,11 +184,16 @@ public class SvrfSDK: NSObject {
 
         dispatchGroup.notify(queue: .main) {
 
+            var pageNum: Int?
+            if let nextPageCursor = options?.nextPageCursor {
+                pageNum = Int(nextPageCursor)
+            }
+
             MediaAPI.getTrending(type: options?.type,
-                                 stereoscopicType: options?.stereoscopicType?.rawValue,
-                                 category: options?.category?.rawValue,
+                                 stereoscopicType: options?.stereoscopicType,
+                                 category: options?.category,
                                  size: options?.size,
-                                 nextPageCursor: options?.nextPageCursor,
+                                 pageNum: pageNum,
                                  completion: { (trendingResponse, error) in
 
                 if let error = error {
@@ -198,7 +203,12 @@ public class SvrfSDK: NSObject {
                     }
                 } else {
                     if let mediaArray = trendingResponse?.media {
-                        success(mediaArray, trendingResponse?.nextPageCursor)
+
+                        var nextPageCursor: String?
+                        if let nextPageNum = trendingResponse?.nextPageNum {
+                            nextPageCursor = String(nextPageNum)
+                        }
+                        success(mediaArray, nextPageCursor)
                     } else if let failure = failure {
                         failure(SvrfError(title: SvrfErrorTitle.responseNoMediaArray.rawValue, description: ""))
                     }

--- a/SvrfSDKTests/SvrfSDKTests.swift
+++ b/SvrfSDKTests/SvrfSDKTests.swift
@@ -30,9 +30,9 @@ class SvrfSDKTests: XCTestCase {
     }
 
     // MARK: - Supporting methods
-    private func autorize(withApiKey apiKey: String,
-                          success: @escaping (_ response: AuthResponse) -> Void,
-                          failure: @escaping (_ error: Error) -> Void) {
+    private func authorize(withApiKey apiKey: String,
+                           success: @escaping (_ response: AuthResponse) -> Void,
+                           failure: @escaping (_ error: Error) -> Void) {
         let body = Body(apiKey: apiKey)
         AuthenticateAPI.authenticate(body: body) { (response, error) in
             if error != nil {
@@ -43,14 +43,14 @@ class SvrfSDKTests: XCTestCase {
         }
     }
 
-    private func searh(query: String,
-                       type: [MediaType]? = nil,
-                       stereoscopicType: String? = nil,
-                       category: String? = nil,
-                       size: Int? = nil,
-                       pageNum: Int? = nil,
-                       success: @escaping (_ response: SearchMediaResponse) -> Void,
-                       failure: @escaping (_ error: Error) -> Void) {
+    private func search(query: String,
+                        type: [MediaType]? = nil,
+                        stereoscopicType: MediaAPI.StereoscopicType_search? = nil,
+                        category: MediaAPI.Category_search? = nil,
+                        size: Int? = nil,
+                        pageNum: Int? = nil,
+                        success: @escaping (_ response: SearchMediaResponse) -> Void,
+                        failure: @escaping (_ error: Error) -> Void) {
         if token != nil {
             SVRFClientAPI.customHeaders = ["x-app-token": token!]
         }
@@ -69,10 +69,10 @@ class SvrfSDKTests: XCTestCase {
     }
 
     private func getTrending(type: [MediaType]? = nil,
-                             stereoscopicType: String? = nil,
-                             category: String? = nil,
+                             stereoscopicType: MediaAPI.StereoscopicType_getTrending? = nil,
+                             category: MediaAPI.Category_getTrending? = nil,
                              size: Int? = nil,
-                             nextPageCursor: String? = nil,
+                             pageNum: Int? = nil,
                              success: @escaping (_ response: TrendingResponse) -> Void,
                              failure: @escaping (_ error: Error) -> Void) {
         if token != nil {
@@ -82,7 +82,7 @@ class SvrfSDKTests: XCTestCase {
                              stereoscopicType: stereoscopicType,
                              category: category,
                              size: size,
-                             nextPageCursor: nextPageCursor) { (trendingResponse, error) in
+                             pageNum: pageNum) { (trendingResponse, error) in
             if error != nil {
                 failure(error!)
             } else {
@@ -108,7 +108,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testAuthenticationWithIncorrectApiKey() {
         let promise = expectation(description: "Authentication request with incorrect apiKey")
-        autorize(withApiKey: incorrectApiKey, success: { _ in
+        authorize(withApiKey: incorrectApiKey, success: { _ in
             XCTFail("""
                     Authentication method finished with success that despite what incorrect key was sent. \
                     Please check authentication method in client API library.
@@ -123,7 +123,7 @@ class SvrfSDKTests: XCTestCase {
     // MARK: - Authentication Tests
     func testAuthenticationWithCorrectApiKey() {
         let promise = expectation(description: "Authentication request with correct apiKey")
-        autorize(withApiKey: correctApiKey, success: { (response) in
+        authorize(withApiKey: correctApiKey, success: { (response) in
             if response.success == nil {
                 XCTFail("Status(success field) in Authenticate response is nill.")
             }
@@ -151,7 +151,7 @@ class SvrfSDKTests: XCTestCase {
     // MARK: - Search Methods Tests
     func testSearchMethodWithEmptyQuery() {
         let promise = expectation(description: "Search request with emty query")
-        searh(query: "", success: { _ in
+        search(query: "", success: { _ in
             XCTFail("""
                     Response for search finished with success despite what empty q was sant. \
                     Please check search method in client API library.
@@ -165,7 +165,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWithNotEmptyQuery() {
         let promise = expectation(description: "Search request with not empty query")
-        searh(query: singleSearchQuery, success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, success: { (searchMediaResponse) in
             if searchMediaResponse.success == nil {
                 XCTFail("Status(success field) in Search method response is nill.")
             }
@@ -197,7 +197,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWithMultipleParameters() {
         let promise = expectation(description: "Search request with multiple parameters")
-        searh(query: singleSearchQuery,
+        search(query: singleSearchQuery,
               type: [MediaType.photo],
               stereoscopicType: nil,
               category: nil,
@@ -217,7 +217,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWithPhotoType() {
         let promise = expectation(description: "Search request with photo type")
-        searh(query: singleSearchQuery, type: [MediaType.photo], success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, type: [MediaType.photo], success: { (searchMediaResponse) in
             var isOnlySearchedType = true
             for mediaObject in searchMediaResponse.media! where mediaObject.type != MediaType.photo {
                 isOnlySearchedType = false
@@ -240,7 +240,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWithVideoType() {
         let promise = expectation(description: "Search request with video type")
-        searh(query: singleSearchQuery, type: [MediaType.video], success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, type: [MediaType.video], success: { (searchMediaResponse) in
             var isOnlySearchedType = true
             for mediaObject in searchMediaResponse.media! where mediaObject.type != MediaType.video {
                 isOnlySearchedType = false
@@ -264,7 +264,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWith3dType() {
         let promise = expectation(description: "Search request with 3d type")
-        searh(query: singleSearchQuery, type: [MediaType._3d], success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, type: [MediaType._3d], success: { (searchMediaResponse) in
             var isOnlySearchedType = true
             for mediaObject in searchMediaResponse.media! where mediaObject.type != MediaType._3d {
                 isOnlySearchedType = false
@@ -287,7 +287,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWithMultipleTypes() {
         let promise = expectation(description: "Search request with multiple types")
-        searh(query: singleSearchQuery, type: [MediaType.video, MediaType.photo], success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, type: [MediaType.video, MediaType.photo], success: { (searchMediaResponse) in
             var isOnlySearchedTypes = true
             for mediaObject in searchMediaResponse.media! where mediaObject.type == MediaType._3d {
                 isOnlySearchedTypes = false
@@ -307,7 +307,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWith5Size() {
         let promise = expectation(description: "Search request with size = 5")
-        searh(query: singleSearchQuery, size: 5, success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, size: 5, success: { (searchMediaResponse) in
             XCTAssertTrue(searchMediaResponse.media!.count == 5,
                           """
                           Search method response contains wrong count of elements. \
@@ -326,7 +326,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWith20Size() {
         let promise = expectation(description: "Search request with size = 20")
-        searh(query: singleSearchQuery, size: 20, success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, size: 20, success: { (searchMediaResponse) in
             XCTAssertTrue(searchMediaResponse.media!.count == 20,
                           """
                           Search method response contains wrong count of elements. \
@@ -345,7 +345,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWith50Size() {
         let promise = expectation(description: "Search request with size = 50")
-        searh(query: singleSearchQuery, size: 50, success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, size: 50, success: { (searchMediaResponse) in
             XCTAssertTrue(searchMediaResponse.media!.count == 50,
                           """
                           Search method response contains wrong count of elements. \
@@ -364,7 +364,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWith70Size() {
         let promise = expectation(description: "Search request with size = 70")
-        searh(query: singleSearchQuery, size: 70, success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, size: 70, success: { (searchMediaResponse) in
             XCTAssertTrue(searchMediaResponse.media!.count == 70,
                           """
                              Search method response contains wrong count of elements. \
@@ -383,7 +383,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWith100Size() {
         let promise = expectation(description: "Search request with size = 100")
-        searh(query: singleSearchQuery, size: 100, success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, size: 100, success: { (searchMediaResponse) in
             XCTAssertTrue(searchMediaResponse.media!.count == 100,
                           """
                           Search method response contains wrong count of elements. \
@@ -402,7 +402,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWith3Page() {
         let promise = expectation(description: "Search request with page = 3")
-        searh(query: singleSearchQuery, pageNum: 3, success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, pageNum: 3, success: { (searchMediaResponse) in
             XCTAssertTrue(searchMediaResponse.pageNum == 3,
                           """
                           Search method response contain wrong count of elements. \
@@ -421,7 +421,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWith15Page() {
         let promise = expectation(description: "Search request with page = 15")
-        searh(query: singleSearchQuery, pageNum: 15, success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, pageNum: 15, success: { (searchMediaResponse) in
             XCTAssertTrue(searchMediaResponse.pageNum == 15,
                           """
                           Search method response contain wrong count of elements. \
@@ -440,7 +440,7 @@ class SvrfSDKTests: XCTestCase {
 
     func testSearchMethodWith40Page() {
         let promise = expectation(description: "Search request with page = 15")
-        searh(query: singleSearchQuery, pageNum: 40, success: { (searchMediaResponse) in
+        search(query: singleSearchQuery, pageNum: 40, success: { (searchMediaResponse) in
             XCTAssertTrue(searchMediaResponse.pageNum == 40,
                           """
                           Search method response contain wrong count of elements. \
@@ -656,15 +656,13 @@ class SvrfSDKTests: XCTestCase {
 
     func testGetTrendingWithNextPageCursor() {
         let promise = expectation(description: "Get trending request with next page cursor")
-        var cursor: String!
         getTrending(success: { [unowned self] (trendingResponse) in
-            cursor = trendingResponse.nextPageCursor
-            self.getTrending(nextPageCursor: cursor, success: { _ in
+            self.getTrending(pageNum: trendingResponse.nextPageNum, success: { _ in
                 promise.fulfill()
             }, failure: { _ in
                 XCTFail("""
                         Get trending method with next page cursor finished with error.
-                        Please check get trending method in client API with nextPageCursor = \(cursor ?? "").
+                        Please check get trending method in client API with nextPageNum.
                         """)
                 promise.fulfill()
             })


### PR DESCRIPTION
# Pull Request

## Description

Any type that declares conformance to the Error protocol can be used to represent an error in Swift’s error handling system.

If your app expects objects that conform to Error you don't need to create special handling for Svrf's error type.

### Motivation and Context

- closes #2116

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [x] Maintenance