### PR TITLE
Conform SvrfError to the Error protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,11 +286,11 @@ class FaceFilter: SCNNode, VirtualFaceContent {
 
 ## Errors
 
-Errors are returned in a custom `SvrfError`. It includes a `title` and `description` to provide you with detailed information for the error you are encountering.
+Errors are returned in a custom `SvrfError`. It includes a  `svrfDescription`  and conforms with default `Error` protocol to provide you with detailed information for the error you are encountering.
 
 ```swift
-print(svrfError.title)
-print(svrfError.description)
+print(svrfError.svrfDescription)
+print(svrfError.localizedDescription)
 ```
 
 [CocoaPods]: https://www.cocoapods.org/

--- a/SvrfSDK/Source/SvrfError.swift
+++ b/SvrfSDK/Source/SvrfError.swift
@@ -8,12 +8,11 @@
 
 import Foundation
 
-public struct SvrfError {
-    public let title: String
-    public let description: String?
+public struct SvrfError: Error {
+    public var svrfDescription: String?
 }
 
-public enum SvrfErrorTitle: String {
+public enum SvrfErrorDescription: String {
 
     enum Auth: String {
         case responseNoToken = "There is no token in the server response."

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -75,8 +75,7 @@ public class SvrfSDK: NSObject {
 
                     if error != nil {
                         if let failure = failure {
-                            failure(SvrfError(title: SvrfErrorTitle.response.rawValue,
-                                              description: error?.localizedDescription))
+                            failure(SvrfError(svrfDescription: SvrfErrorDescription.response.rawValue))
                         }
 
                         dispatchGroup.leave()
@@ -99,7 +98,7 @@ public class SvrfSDK: NSObject {
                         return
                     } else {
                         if let failure = failure {
-                            failure(SvrfError(title: SvrfErrorTitle.Auth.responseNoToken.rawValue, description: nil))
+                            failure(SvrfError(svrfDescription: SvrfErrorDescription.Auth.responseNoToken.rawValue))
                         }
 
                         dispatchGroup.leave()
@@ -109,7 +108,7 @@ public class SvrfSDK: NSObject {
                 }
             } else {
                 if let failure = failure {
-                    failure(SvrfError(title: SvrfErrorTitle.Auth.apiKey.rawValue, description: nil))
+                    failure(SvrfError(svrfDescription: SvrfErrorDescription.Auth.apiKey.rawValue))
                 }
 
                 dispatchGroup.leave()
@@ -153,15 +152,15 @@ public class SvrfSDK: NSObject {
                             completion: { (searchMediaResponse, error) in
 
                 if let error = error {
-                    if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.response.rawValue,
-                                          description: error.localizedDescription))
+                    if let failure = failure, var svrfError = error as? SvrfError {
+                        svrfError.svrfDescription = SvrfErrorDescription.response.rawValue
+                        failure(svrfError)
                     }
                 } else {
                     if let mediaArray = searchMediaResponse?.media {
                         success(mediaArray, searchMediaResponse?.nextPageNum)
                     } else if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.responseNoMediaArray.rawValue, description: nil))
+                        failure(SvrfError(svrfDescription: SvrfErrorDescription.responseNoMediaArray.rawValue))
                     }
                 }
             })
@@ -201,15 +200,15 @@ public class SvrfSDK: NSObject {
                                  completion: { (trendingResponse, error) in
 
                 if let error = error {
-                    if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.response.rawValue,
-                                          description: error.localizedDescription))
+                    if let failure = failure, var svrfError = error as? SvrfError {
+                        svrfError.svrfDescription = SvrfErrorDescription.response.rawValue
+                        failure(svrfError)
                     }
                 } else {
                     if let mediaArray = trendingResponse?.media {
                         success(mediaArray, trendingResponse?.nextPageNum)
                     } else if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.responseNoMediaArray.rawValue, description: ""))
+                        failure(SvrfError(svrfDescription: SvrfErrorDescription.responseNoMediaArray.rawValue))
                     }
                 }
             })
@@ -235,15 +234,15 @@ public class SvrfSDK: NSObject {
             MediaAPI.getById(id: identifier, completion: { (singleMediaResponse, error) in
 
                 if let error = error {
-                    if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.response.rawValue,
-                                          description: error.localizedDescription))
+                    if let failure = failure, var svrfError = error as? SvrfError {
+                        svrfError.svrfDescription = SvrfErrorDescription.response.rawValue
+                        failure(svrfError)
                     }
                 } else {
                     if let media = singleMediaResponse?.media {
                         success(media)
                     } else if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.response.rawValue, description: nil))
+                        failure(SvrfError(svrfDescription: SvrfErrorDescription.response.rawValue))
                     }
                 }
             })
@@ -270,10 +269,10 @@ public class SvrfSDK: NSObject {
             if let scene = getSceneFromMedia(media: media) {
                 success(scene.rootNode)
             } else if let failure = failure {
-                failure(SvrfError(title: SvrfErrorTitle.getScene.rawValue, description: nil))
+                failure(SvrfError(svrfDescription: SvrfErrorDescription.getScene.rawValue))
             }
         } else if let failure = failure {
-            failure(SvrfError(title: SvrfErrorTitle.incorrectMediaType.rawValue, description: nil))
+            failure(SvrfError(svrfDescription: SvrfErrorDescription.incorrectMediaType.rawValue))
         }
     }
 
@@ -305,7 +304,7 @@ public class SvrfSDK: NSObject {
             })
         }
     }
-    
+
     /**
      The SVRF API allows you to access all of SVRF's ARKit compatible face filters and stream them directly to your app.
      Use the `getFaceFilter` method to stream a face filter to your app and convert it into a *SCNNode* in runtime.
@@ -345,8 +344,7 @@ public class SvrfSDK: NSObject {
                                                 properties: ["media_id": media.id ?? "unknown"])
                 } catch {
                     if let failure = failure {
-                        failure(SvrfError(title: SvrfErrorTitle.getScene.rawValue,
-                                          description: error.localizedDescription))
+                        failure(SvrfError(svrfDescription: SvrfErrorDescription.getScene.rawValue))
                     }
                 }
             }


### PR DESCRIPTION
# Pull Request

## Description

Would be nice if SvrfError conformed to the Error protocol.

Any type that declares conformance to the Error protocol can be used to represent an error in Swift’s error handling system.

If your app expects objects that conform to Error you don't need to create special handling for Svrf's error type.

### Motivation and Context

- closes #46 

### Checklist

- [x] Documentation
- [ ] Tests