### PR TITLE
Rename getNodeFromMedia and getFaceFilter to use the same naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Get a face filter *SCNNode* for *Media* with ID "547963".
 
 ```swift
 SvrfSDK.getMedia(id: "547963", onSuccess: { media in
-    SvrfSDK.generateFaceFilterNode(with: media, onSuccess: { faceFilter in
+    SvrfSDK.generateFaceFilterNode(for: media, onSuccess: { faceFilterNode in
         // Do what you want with the face filter
     }, onFailure: { error in
         print("\(error.title). \(error.description ?? "")")

--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ SvrfSDK.getMedia(id: "547963", onSuccess: { media in
 
 ## Utilities
 
-### getNodeFromMedia
+### generateNode
 
-Generates a *SCNNode* for a *Media* with a *type* "3d". This method can used to generate the whole 3D model, but is not recommended for face filters. **Face filters should be retrieved using the [`getFaceFilter`](#getFaceFilter) method.**
+Generates a *SCNNode* for a *Media* with a *type* "3d". This method can used to generate the whole 3D model, but is not recommended for face filters. **Face filters should be retrieved using the [`generateFaceFilterNode`](#generateFaceFilterNode) method.**
 
 | Parameter                     | Type                                            |
 | :---                          | :---                                            |
@@ -215,7 +215,7 @@ Get *SCNNode* from *Media* with ID "547963".
 
 ```swift
 SvrfSDK.getMedia(id: "547963", onSuccess: { media in
-    SvrfSDK.getNodeFromMedia(media: media, onSuccess: { node in
+    SvrfSDK.generateNode(for: media, onSuccess: { node in
         // Do what you want with the SCNNode
     }, onFailure: { error in
         print("\(error.title). \(error.description ?? "")")
@@ -225,9 +225,9 @@ SvrfSDK.getMedia(id: "547963", onSuccess: { media in
 }
 ```
 
-### getFaceFilter
+### generateFaceFilterNode
 
-The SVRF API allows you to access all of SVRF's ARKit compatible face filters and stream them directly to your app. Use the `getFaceFilter` method to stream a face filter to your app and convert it into a *SCNNode* in runtime. You can then attach the face filter to a *SCNScene*
+The SVRF API allows you to access all of SVRF's ARKit compatible face filters and stream them directly to your app. Use the `generateFaceFilterNode` method to stream a face filter to your app and convert it into a *SCNNode* in runtime. You can then attach the face filter to a *SCNScene*
 
 | Parameter                     | Type                                            |
 | :---                          | :---                                            |
@@ -243,7 +243,7 @@ Get a face filter *SCNNode* for *Media* with ID "547963".
 
 ```swift
 SvrfSDK.getMedia(id: "547963", onSuccess: { media in
-    SvrfSDK.getFaceFilter(with: media, onSuccess: { faceFilter in
+    SvrfSDK.generateFaceFilterNode(with: media, onSuccess: { faceFilter in
         // Do what you want with the face filter
     }, onFailure: { error in
         print("\(error.title). \(error.description ?? "")")

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -308,7 +308,7 @@ public class SvrfSDK: NSObject {
 
     /**
      The SVRF API allows you to access all of SVRF's ARKit compatible face filters and stream them directly to your app.
-     Use the `getFaceFilter` method to stream a face filter to your app and convert it into a *SCNNode* in runtime.
+     Use the `generateFaceFilterNode` method to stream a face filter to your app and convert it into a *SCNNode* in runtime.
      
      - Parameters:
         - media: The *Media* to generate the node from. The *type* must be `_3d`.

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -311,7 +311,7 @@ public class SvrfSDK: NSObject {
      Use the `generateFaceFilterNode` method to stream a face filter to your app and convert it into a *SCNNode* in runtime.
      
      - Parameters:
-        - media: The *Media* to generate the node from. The *type* must be `_3d`.
+        - media: The *Media* to generate the face filter node from. The *type* must be `_3d`.
         - success: Success closure.
         - faceFilter: The *SCNNode* that contains face filter content.
         - failure: Error closure.

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -325,21 +325,21 @@ public class SvrfSDK: NSObject {
                 let modelSource = GLTFSceneSource(url: glbUrl)
 
                 do {
-                    let node = SCNNode()
+                    let faceFilterNode = SCNNode()
                     let sceneNode = try modelSource.scene().rootNode
 
                     if let occluderNode = sceneNode.childNode(withName: ChildNode.occluder.rawValue, recursively: true) {
-                        node.addChildNode(occluderNode)
+                        faceFilterNode.addChildNode(occluderNode)
                         setOccluderNode(node: occluderNode)
                     }
 
                     if let headNode = sceneNode.childNode(withName: ChildNode.head.rawValue, recursively: true) {
-                        node.addChildNode(headNode)
+                        faceFilterNode.addChildNode(headNode)
                     }
 
-                    node.morpher?.calculationMode = SCNMorpherCalculationMode.normalized
+                    faceFilterNode.morpher?.calculationMode = SCNMorpherCalculationMode.normalized
 
-                    success(node)
+                    success(faceFilterNode)
 
                     SEGAnalytics.shared().track("Face Filter Node Requested",
                                                 properties: ["media_id": media.id ?? "unknown"])

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -254,7 +254,7 @@ public class SvrfSDK: NSObject {
      Generates a *SCNNode* for a *Media* with a *type* `_3d`. This method can used to generate
      the whole 3D model, but is not recommended for face filters.
      
-     - Attention: Face filters should be retrieved using the `getNode` method.
+     - Attention: Face filters should be retrieved using the `getFaceFilterNode` method.
      - Parameters:
         - media: The *Media* to generate the *SCNNode* from. The *type* must be `_3d`.
         - success: Success closure.
@@ -317,8 +317,8 @@ public class SvrfSDK: NSObject {
         - failure: Error closure.
         - error: A *SvrfError*.
      */
-    public static func generateFaceFilterNode(with media: Media,
-                                     onSuccess success: @escaping (_ node: SCNNode) -> Void,
+    public static func generateFaceFilterNode(for media: Media,
+                                     onSuccess success: @escaping (_ faceFilterNode: SCNNode) -> Void,
                                      onFailure failure: Optional<(_ error: SvrfError) -> Void> = nil) {
 
             if media.type == ._3d, let glbUrlString = media.files?.glb, let glbUrl = URL(string: glbUrlString) {
@@ -341,7 +341,7 @@ public class SvrfSDK: NSObject {
 
                     success(node)
 
-                    SEGAnalytics.shared().track("Node Requested",
+                    SEGAnalytics.shared().track("Face Filter Node Requested",
                                                 properties: ["media_id": media.id ?? "unknown"])
                 } catch {
                     if let failure = failure {

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -317,7 +317,7 @@ public class SvrfSDK: NSObject {
         - failure: Error closure.
         - error: A *SvrfError*.
      */
-    public static func getNode(with media: Media,
+    public static func generateFaceFilterNode(with media: Media,
                                      onSuccess success: @escaping (_ node: SCNNode) -> Void,
                                      onFailure failure: Optional<(_ error: SvrfError) -> Void> = nil) {
 


### PR DESCRIPTION
# Pull Request

## Description

- When using the integrating a 3rd party API, I want to have it work as simple and predictable as possible, so I don't have to worry about weird intricacies of integrating, and instead build great features.

### Motivation and Context

- closes #2225

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [x] Maintenance

### Checklist

- [x] Documentation
- [ ] Tests