### PR TITLE
Make Scene/Node generation asynchronous for remote URLs, return DataT…

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ target 'SvrfSDK' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
   pod 'SVRFClient', '~> 1.6.0'
-  pod 'SvrfGLTFSceneKit', '~> 1.0'
+  pod 'SvrfGLTFSceneKit', '~> 1.0.2'
   pod 'Analytics', '~> 3.0'
 
   # Pods for SvrfSDK

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -319,7 +319,7 @@ public class SvrfSDK: NSObject {
         - faceFilter: The *SCNNode* that contains face filter content.
         - failure: Error closure.
         - error: A *SvrfError*.
-     - Returns: URLSessionDataTask for the in-flight request
+     - Returns: URLSessionDataTask? for the in-flight request
      */
     public static func generateFaceFilterNode(for media: Media,
                                      onSuccess success: @escaping (_ faceFilterNode: SCNNode) -> Void,

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -318,39 +318,40 @@ public class SvrfSDK: NSObject {
         - faceFilter: The *SCNNode* that contains face filter content.
         - failure: Error closure.
         - error: A *SvrfError*.
+     - Returns: URLSessionDataTask for use in keeping track of this request & canceling
      */
     public static func generateFaceFilterNode(for media: Media,
                                      onSuccess success: @escaping (_ faceFilterNode: SCNNode) -> Void,
-                                     onFailure failure: Optional<(_ error: SvrfError) -> Void> = nil) {
+                                     onFailure failure: Optional<(_ error: SvrfError) -> Void> = nil) -> URLSessionDataTask {
 
             if media.type == ._3d, let glbUrlString = media.files?.glb, let glbUrl = URL(string: glbUrlString) {
-                let modelSource = GLTFSceneSource(url: glbUrl)
 
-                do {
-                    let faceFilterNode = SCNNode()
-                    let sceneNode = try modelSource.scene().rootNode
-
-                    if let occluderNode = sceneNode.childNode(withName: ChildNode.occluder.rawValue, recursively: true) {
-                        faceFilterNode.addChildNode(occluderNode)
-                        setOccluderNode(node: occluderNode)
+                return GLTFSceneSource.load(remoteURL: glbUrl, onSuccess: { modelSource in
+                    do {
+                        let faceFilterNode = SCNNode()
+                        let sceneNode = try modelSource.scene().rootNode
+                        
+                        if let occluderNode = sceneNode.childNode(withName: ChildNode.occluder.rawValue, recursively: true) {
+                            faceFilterNode.addChildNode(occluderNode)
+                            setOccluderNode(node: occluderNode)
+                        }
+                        
+                        if let headNode = sceneNode.childNode(withName: ChildNode.head.rawValue, recursively: true) {
+                            faceFilterNode.addChildNode(headNode)
+                        }
+                        
+                        faceFilterNode.morpher?.calculationMode = SCNMorpherCalculationMode.normalized
+                        
+                        success(faceFilterNode)
+                        
+                        SEGAnalytics.shared().track("Face Filter Node Requested",
+                                                    properties: ["media_id": media.id ?? "unknown"])
+                    } catch {
+                        failure?(SvrfError(svrfDescription: SvrfErrorDescription.getScene.rawValue))
                     }
-
-                    if let headNode = sceneNode.childNode(withName: ChildNode.head.rawValue, recursively: true) {
-                        faceFilterNode.addChildNode(headNode)
-                    }
-
-                    faceFilterNode.morpher?.calculationMode = SCNMorpherCalculationMode.normalized
-
-                    success(faceFilterNode)
-
-                    SEGAnalytics.shared().track("Face Filter Node Requested",
-                                                properties: ["media_id": media.id ?? "unknown"])
-                } catch {
-                    if let failure = failure {
-                        failure(SvrfError(svrfDescription: SvrfErrorDescription.getScene.rawValue))
-                    }
-                }
-            }
+                }, onFailure: { error in
+                    failure?(SvrfError(svrfDescription: error.localizedDescription))
+                })
         }
 
         // MARK: private functions

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -323,37 +323,40 @@ public class SvrfSDK: NSObject {
      */
     public static func generateFaceFilterNode(for media: Media,
                                      onSuccess success: @escaping (_ faceFilterNode: SCNNode) -> Void,
-                                     onFailure failure: Optional<(_ error: SvrfError) -> Void> = nil) -> URLSessionDataTask {
+                                     onFailure failure: Optional<(_ error: SvrfError) -> Void> = nil) -> URLSessionDataTask? {
 
-            if media.type == ._3d, let glbUrlString = media.files?.glb, let glbUrl = URL(string: glbUrlString) {
-
-                return GLTFSceneSource.load(remoteURL: glbUrl, onSuccess: { modelSource in
-                    do {
-                        let faceFilterNode = SCNNode()
-                        let sceneNode = try modelSource.scene().rootNode
-                        
-                        if let occluderNode = sceneNode.childNode(withName: ChildNode.occluder.rawValue, recursively: true) {
-                            faceFilterNode.addChildNode(occluderNode)
-                            setOccluderNode(node: occluderNode)
-                        }
-                        
-                        if let headNode = sceneNode.childNode(withName: ChildNode.head.rawValue, recursively: true) {
-                            faceFilterNode.addChildNode(headNode)
-                        }
-                        
-                        faceFilterNode.morpher?.calculationMode = SCNMorpherCalculationMode.normalized
-                        
-                        success(faceFilterNode)
-                        
-                        SEGAnalytics.shared().track("Face Filter Node Requested",
-                                                    properties: ["media_id": media.id ?? "unknown"])
-                    } catch {
-                        failure?(SvrfError(svrfDescription: SvrfErrorDescription.getScene.rawValue))
-                    }
-                }, onFailure: { error in
-                    failure?(SvrfError(svrfDescription: error.localizedDescription))
-                })
+        guard media.type == ._3d, let glbUrlString = media.files?.glb, let glbUrl = URL(string: glbUrlString) else {
+            failure?(SvrfError(svrfDescription: "Invalid media sent to generateFaceFilterNode: \(media)"))
+            return nil
         }
+        
+        return GLTFSceneSource.load(remoteURL: glbUrl, onSuccess: { modelSource in
+            do {
+                let faceFilterNode = SCNNode()
+                let sceneNode = try modelSource.scene().rootNode
+                
+                if let occluderNode = sceneNode.childNode(withName: ChildNode.occluder.rawValue, recursively: true) {
+                    faceFilterNode.addChildNode(occluderNode)
+                    setOccluderNode(node: occluderNode)
+                }
+                
+                if let headNode = sceneNode.childNode(withName: ChildNode.head.rawValue, recursively: true) {
+                    faceFilterNode.addChildNode(headNode)
+                }
+                
+                faceFilterNode.morpher?.calculationMode = SCNMorpherCalculationMode.normalized
+                
+                success(faceFilterNode)
+                
+                SEGAnalytics.shared().track("Face Filter Node Requested",
+                                            properties: ["media_id": media.id ?? "unknown"])
+            } catch {
+                failure?(SvrfError(svrfDescription: SvrfErrorDescription.getScene.rawValue))
+            }
+        }, onFailure: { error in
+            failure?(SvrfError(svrfDescription: error.localizedDescription))
+        })
+    }
 
         // MARK: private functions
         /**

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -365,7 +365,7 @@ public class SvrfSDK: NSObject {
          - Parameters:
             - media: The *Media* to return a *SCNScene* from.
             - success: The success block that returns the *SCNScene*, if loaded.
-         - Returns: URLSessionDataTask for the in-flight request
+         - Returns: URLSessionDataTask? for the in-flight request
          */
     private static func loadSceneFromMedia(media: Media,
                                            onSuccess success: @escaping (_ scene: SCNScene) -> Void,

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -260,6 +260,7 @@ public class SvrfSDK: NSObject {
         - node: The *SCNNode* generated from the *Media*.
         - failure: Error closure.
         - error: A *SvrfError*.
+     - Returns: URLSessionDataTask for the in-flight request
      */
     public static func generateNode(for media: Media,
                                     onSuccess success: @escaping (_ node: SCNNode) -> Void,
@@ -318,7 +319,7 @@ public class SvrfSDK: NSObject {
         - faceFilter: The *SCNNode* that contains face filter content.
         - failure: Error closure.
         - error: A *SvrfError*.
-     - Returns: URLSessionDataTask for use in keeping track of this request & canceling
+     - Returns: URLSessionDataTask for the in-flight request
      */
     public static func generateFaceFilterNode(for media: Media,
                                      onSuccess success: @escaping (_ faceFilterNode: SCNNode) -> Void,
@@ -361,7 +362,7 @@ public class SvrfSDK: NSObject {
          - Parameters:
             - media: The *Media* to return a *SCNScene* from.
             - success: The success block that returns the *SCNScene*, if loaded.
-         - Returns: URLSessionDataTask for use in keeping track of this request & canceling
+         - Returns: URLSessionDataTask for the in-flight request
          */
     private static func loadSceneFromMedia(media: Media,
                                            onSuccess success: @escaping (_ scene: SCNScene) -> Void,


### PR DESCRIPTION
…ask for management outside of SDK

# Pull Request

## Description

This:
- moves the SDK to an asynchronous model fetch, which means users can now call `generateNode(...)` from the main thread
- Returns a `URLSessionDataTask` that can be used to later cancel() - see the demo code [here](https://github.com/jexe/svrf-api/commit/18750300dce4308b9b1a99d87eb15b3dc008193a)

### Motivation and Context

- closes #30 and #50 
- depends on https://github.com/Svrf/SvrfGLTFSceneKit/pull/3

### Types of changes

- [X] Bug fix
- [X] New feature
- [ ] Maintenance

### Checklist

- [X] Documentation
- [ :( ] Tests