### PR TITLE
Proposed change to return a SvrfRequest from API calls

### DIFF
--- a/SvrfSDK.xcodeproj/project.pbxproj
+++ b/SvrfSDK.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		7646973942EFB87EA520150F /* Pods_SvrfSDK_SvrfSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB17013FE34F4D97096AB226 /* Pods_SvrfSDK_SvrfSDKTests.framework */; };
 		887CE43B22AFFCAF007F8553 /* SvrfFaceFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887CE43A22AFFCAE007F8553 /* SvrfFaceFilter.swift */; };
 		887CE43C22AFFCAF007F8553 /* SvrfFaceFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887CE43A22AFFCAE007F8553 /* SvrfFaceFilter.swift */; };
+		883F191322BA89150036430A /* SvrfRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883F191222BA89150036430A /* SvrfRequest.swift */; };
+		883F191422BA89150036430A /* SvrfRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883F191222BA89150036430A /* SvrfRequest.swift */; };
 		9A866D7E60EE7626BE3E912A /* Pods_SvrfSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7271369A8F168B0107ADF84 /* Pods_SvrfSDK.framework */; };
 		EC1AB98F229D24D3003FCA5D /* SvrfTrendingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1AB981229D24D2003FCA5D /* SvrfTrendingResponse.swift */; };
 		EC1AB990229D24D3003FCA5D /* SvrfMediaVideos.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1AB982229D24D2003FCA5D /* SvrfMediaVideos.swift */; };
@@ -63,6 +65,7 @@
 		553C4BE026B71D4586A81734 /* Pods-SvrfSDK-SvrfSDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SvrfSDK-SvrfSDKTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SvrfSDK-SvrfSDKTests/Pods-SvrfSDK-SvrfSDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		6E29DB7E0DC463087DAF7608 /* Pods-SvrfSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SvrfSDKTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SvrfSDKTests/Pods-SvrfSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		887CE43A22AFFCAE007F8553 /* SvrfFaceFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SvrfFaceFilter.swift; sourceTree = "<group>"; };
+		883F191222BA89150036430A /* SvrfRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SvrfRequest.swift; sourceTree = "<group>"; };
 		A3ECC94D5CBB1EAC5B159AE8 /* Pods-SvrfSDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SvrfSDKTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SvrfSDKTests/Pods-SvrfSDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		AB17013FE34F4D97096AB226 /* Pods_SvrfSDK_SvrfSDKTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SvrfSDK_SvrfSDKTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2EED774328EC0E3858EADA3 /* Pods-SvrfSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SvrfSDK.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SvrfSDK/Pods-SvrfSDK.debug.xcconfig"; sourceTree = "<group>"; };
@@ -188,6 +191,7 @@
 				EC75A3CC219AAD23003C1108 /* SvrfError.swift */,
 				EC1EF181219A11F6006F12B0 /* SvrfSDK.swift */,
 				887CE43A22AFFCAE007F8553 /* SvrfFaceFilter.swift */,
+				883F191222BA89150036430A /* SvrfRequest.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -436,6 +440,7 @@
 			files = (
 				EC1AB997229D24D3003FCA5D /* SvrfMediaImages.swift in Sources */,
 				EC1AB995229D24D3003FCA5D /* SvrfMedia.swift in Sources */,
+				883F191322BA89150036430A /* SvrfRequest.swift in Sources */,
 				EC1AB99B229D24D3003FCA5D /* SvrfMediaFiles.swift in Sources */,
 				EC1AB994229D24D3003FCA5D /* SvrfMediaType.swift in Sources */,
 				EC1EF182219A11F6006F12B0 /* SvrfSDK.swift in Sources */,
@@ -460,6 +465,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				883F191422BA89150036430A /* SvrfRequest.swift in Sources */,
 				EC1EF176219A1189006F12B0 /* SvrfSDKTests.swift in Sources */,
 				887CE43C22AFFCAF007F8553 /* SvrfFaceFilter.swift in Sources */,
 			);

--- a/SvrfSDK/Source/SvrfRequest.swift
+++ b/SvrfSDK/Source/SvrfRequest.swift
@@ -1,0 +1,36 @@
+//
+//  SvrfRequest.swift
+//  SvrfSDK
+//
+//  Created by Jesse Boyes on 6/19/19.
+//  Copyright © 2019 Svrf. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+public enum SvrfRequestState {
+    case initialized
+    case queued
+    case canceled
+    case active(DataRequest?)
+    case completed
+}
+
+public class SvrfRequest: NSObject {
+    public var state: SvrfRequestState {
+        willSet(newState) {
+            if case .canceled = newState, case .active(let dataRequest?) = state {
+                dataRequest.cancel()
+            }
+        }
+    }
+
+    override public init() {
+        state = .initialized
+    }
+
+    public func cancel() {
+        self.state = .canceled
+    }
+}

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -121,24 +121,27 @@ public class SvrfSDK: NSObject {
         - nextPageNum: The page number of the next page.
         - failure: Error closure.
         - error: A *SvrfError*.
-     - Returns: DataRequest? for the in-flight request
+     - Returns: `SvrfRequest` for the in-flight request
      */
     public static func search(query: String,
                               options: SvrfOptions,
                               onSuccess success: @escaping (_ mediaArray: [SvrfMedia],
                                                             _ nextPageNum: Int?) -> Void,
                               // swiftlint:disable:next syntactic_sugar
-                              onFailure failure: Optional<((_ error: SvrfError) -> Void)> = nil) -> DataRequest? {
+                              onFailure failure: Optional<((_ error: SvrfError) -> Void)> = nil) -> SvrfRequest {
 
-        dispatchGroup.notify(queue: .main) {
+        return queuedRequest { svrfRequest in
+            return SvrfAPIManager.search(query: query, options: options, onSuccess: { searchResponse in
+                svrfRequest.state = .completed
 
-            return _ = SvrfAPIManager.search(query: query, options: options, onSuccess: { searchResponse in
                 if let mediaArray = searchResponse.media {
                     success(mediaArray, searchResponse.nextPageNum)
                 } else if let failure = failure {
                     failure(SvrfError(svrfDescription: SvrfErrorDescription.responseNoMediaArray.rawValue))
                 }
             }, onFailure: { error in
+                svrfRequest.state = .completed
+
                 if let failure = failure, var svrfError = error as? SvrfError {
                     svrfError.svrfDescription = SvrfErrorDescription.response.rawValue
                     failure(svrfError)
@@ -146,8 +149,6 @@ public class SvrfSDK: NSObject {
 
             })
         }
-
-        return nil
     }
 
     /**
@@ -163,17 +164,19 @@ public class SvrfSDK: NSObject {
         - nextPageNum: Number of the next page.
         - failure: Error closure.
         - error: A *SvrfError*.
-     - Returns: DataRequest? for the in-flight request
+     - Returns: `SvrfRequest` for the in-flight request
      */
     public static func getTrending( options: SvrfOptions?,
                                     onSuccess success: @escaping (_ mediaArray: [SvrfMedia],
                                                                   _ nextPageNum: Int?) -> Void,
                                     // swiftlint:disable:next syntactic_sugar
-                                    onFailure failure: Optional<((_ error: SvrfError) -> Void)> = nil) -> DataRequest? {
+                                    onFailure failure: Optional<((_ error: SvrfError) -> Void)> = nil) -> SvrfRequest {
 
-        dispatchGroup.notify(queue: .main) {
+        return queuedRequest { svrfRequest in
 
-            return _ = SvrfAPIManager.getTrending(options: options, onSuccess: { trendingResponse in
+            return SvrfAPIManager.getTrending(options: options, onSuccess: { trendingResponse in
+                svrfRequest.state = .completed
+
                 if let mediaArray = trendingResponse.media {
                     success(mediaArray, trendingResponse.nextPageNum)
                 } else if let failure = failure {
@@ -181,15 +184,14 @@ public class SvrfSDK: NSObject {
                 }
 
             }, onFailure: { error in
+                svrfRequest.state = .completed
+
                 if let failure = failure, var svrfError = error as? SvrfError {
                     svrfError.svrfDescription = SvrfErrorDescription.response.rawValue
                     failure(svrfError)
                 }
-
             })
         }
-
-        return nil
     }
 
     /**
@@ -206,17 +208,21 @@ public class SvrfSDK: NSObject {
     public static func getMedia(id: String,
                                 onSuccess success: @escaping (_ media: SvrfMedia) -> Void,
                                 // swiftlint:disable:next syntactic_sugar
-                                onFailure failure: Optional<((_ error: SvrfError) -> Void)> = nil) -> DataRequest? {
+                                onFailure failure: Optional<((_ error: SvrfError) -> Void)> = nil) -> SvrfRequest {
 
-        dispatchGroup.notify(queue: .main) {
+        return queuedRequest { svrfRequest in
 
-            return _ = SvrfAPIManager.getMedia(by: id, onSuccess: { mediaResponse in
+            return SvrfAPIManager.getMedia(by: id, onSuccess: { mediaResponse in
+                svrfRequest.state = .completed
+
                 if let media = mediaResponse.media {
                     success(media)
                 } else if let failure = failure {
                     failure(SvrfError(svrfDescription: SvrfErrorDescription.response.rawValue))
                 }
             }, onFailure: { error in
+                svrfRequest.state = .completed
+
                 if let failure = failure, var svrfError = error as? SvrfError {
                     svrfError.svrfDescription = SvrfErrorDescription.response.rawValue
                     failure(svrfError)
@@ -224,8 +230,6 @@ public class SvrfSDK: NSObject {
 
             })
         }
-
-        return nil
     }
 
     /**
@@ -263,7 +267,7 @@ public class SvrfSDK: NSObject {
                                               useOccluder: Bool = true,
                                               onSuccess success: @escaping (_ faceFilter: SvrfFaceFilter) -> Void,
                                               // swiftlint:disable:next syntactic_sugar
-        onFailure failure: Optional<((_ error: SvrfError) -> Void)> = nil) -> URLSessionDataTask? {
+                                              onFailure failure: Optional<((_ error: SvrfError) -> Void)> = nil) -> URLSessionDataTask? {
 
         guard media.type == ._3d, let glbUrlString = media.files?.glb, let glbUrl = URL(string: glbUrlString) else {
             failure?(SvrfError(svrfDescription: "Invalid media sent to generateFaceFilterNode: \(media)"))
@@ -308,6 +312,33 @@ public class SvrfSDK: NSObject {
     }
 
     // MARK: private functions
+
+    /**
+     Runs a request on the dispatchGroup.
+
+     - Note:  `requestBlock` is responsible for setting the `svrfRequest` to .completed once finished.
+     - Returns: a `SvrfRequest` most likely in `.queued` state.
+     */
+    private static func queuedRequest(_ requestBlock: @escaping (SvrfRequest) -> DataRequest?) -> SvrfRequest {
+        let request = SvrfRequest()
+        request.state = .queued
+
+        dispatchGroup.notify(queue: .main) {
+            // Kick off the request if we are in the queued state.
+            switch request.state {
+            case .queued:
+                let dataRequest = requestBlock(request)
+                request.state = .active(dataRequest)
+            case .canceled: break
+            case .completed: print("Error: Trying to run a completed request")
+            default: print("Unhandled state \(request.state)")
+            }
+        }
+
+        return request
+    }
+
+
     /**
      Renders a *SCNScene* from a *Media*'s glb file using *SvrfGLTFSceneKit*.
      
@@ -322,7 +353,7 @@ public class SvrfSDK: NSObject {
 
         if let glbUrlString = media.files?.glb {
             if let glbUrl = URL(string: glbUrlString) {
-
+s
                 return GLTFSceneSource.load(remoteURL: glbUrl, onSuccess: { modelSource in
 
                     do {


### PR DESCRIPTION
The SvrfRequest will be populated with an operating request once it is dequeued and fired off

# Pull Request

## Description

Solving issue 2322 in svrf-wave

https://app.zenhub.com/workspaces/engineering-5c520101e050c96f3e496a62/issues/svrf/svrf-wave/2322

For discussion:
- Noticed in coding this that different requests return different types of requests. Should all API calls return some kind of `SvrfRequest` for a consistent interface, whether they're enqueued or not?

### Motivation and Context

See Option 4 in the discussion under this issue. 

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Maintenance

