### PR TITLE
Expose the Occluder getter

### DIFF
--- a/SvrfSDK.podspec
+++ b/SvrfSDK.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name = "SvrfSDK"
-  s.version = "3.1.0"
+  s.version = "3.1.1"
   s.summary = "The SvrfSDK is a framework for easy integration of the Svrf API."
   s.homepage = "http://www.svrf.com"
   s.license = "MIT"
   s.author = "Svrf"
   s.platform = :ios, "11.0"
-  s.source = { :git => "https://github.com/SVRF/svrf-ios-sdk.git", :tag => "3.1.0" }
+  s.source = { :git => "https://github.com/SVRF/svrf-ios-sdk.git", :tag => "3.1.1" }
   s.source_files = "SvrfSDK/Source/*"
   s.resources = "SvrfSDK/Resources/Occluder.glb"
   s.dependency 'SvrfGLTFSceneKit', '~> 1.3'

--- a/SvrfSDK/Info.plist
+++ b/SvrfSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.0</string>
+	<string>3.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/SvrfSDK/Source/SvrfSDK.swift
+++ b/SvrfSDK/Source/SvrfSDK.swift
@@ -331,6 +331,21 @@ public class SvrfSDK: NSObject {
         })
     }
 
+    /**
+     Loads or returns the single instance of the Svrf occluder node for use with face filters loaded from the API.
+    - Returns: Svrf's Occluder *SCNNode*.
+     */
+    public static func occluderNode() throws -> SCNNode {
+        if occluder == nil {
+            let bundle = Bundle(for: self)
+            let path = bundle.path(forResource: "Occluder", ofType: "glb", inDirectory: "")
+            let modelSource = try GLTFSceneSource(path: path!)
+            occluder = try modelSource.scene().rootNode
+        }
+
+        return occluder!
+    }
+
     // MARK: private functions
 
     /**
@@ -356,17 +371,6 @@ public class SvrfSDK: NSObject {
         }
 
         return request
-    }
-
-    private static func occluderNode() throws -> SCNNode {
-        if occluder == nil {
-            let bundle = Bundle(for: self)
-            let path = bundle.path(forResource: "Occluder", ofType: "glb", inDirectory: "")
-            let modelSource = try GLTFSceneSource(path: path!)
-            occluder = try modelSource.scene().rootNode
-        }
-
-        return occluder!
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## Description

Exposes the Occluder node getter - this will let us maintain the occluder on the Scene hierarchy separate from being a child node in the model.

### Motivation and Context

- https://github.com/Svrf/svrf-wave/issues/2555


### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Maintenance

### Checklist

- [x] Documentation
- [ ] Tests